### PR TITLE
Revert phpredis to 5.3.7 due to a bug in 6.0.0

### DIFF
--- a/php/8.1-dev/Dockerfile
+++ b/php/8.1-dev/Dockerfile
@@ -26,7 +26,7 @@ RUN set -eux; \
         apk add --no-cache --virtual .build-deps autoconf re2c gcc make g++ zlib-dev php81-dev; \
         pear81 update-channels; \
         pecl81 update-channels; \
-        pecl81 install --onlyreqdeps --nobuild redis; \
+        pecl81 install --onlyreqdeps --nobuild redis-5.3.7; \
         pecl81 install igbinary; \
         cd "$(pecl81 config-get temp_dir)/redis"; \
         phpize81; \

--- a/php/8.1/Dockerfile
+++ b/php/8.1/Dockerfile
@@ -26,7 +26,7 @@ RUN set -eux; \
         apk add --no-cache --virtual .build-deps autoconf re2c gcc make g++ zlib-dev php81-dev; \
         pear81 update-channels; \
         pecl81 update-channels; \
-        pecl81 install --onlyreqdeps --nobuild redis; \
+        pecl81 install --onlyreqdeps --nobuild redis-5.3.7; \
         pecl81 install igbinary; \
         cd "$(pecl81 config-get temp_dir)/redis"; \
         phpize81; \

--- a/php/8.2-dev/Dockerfile
+++ b/php/8.2-dev/Dockerfile
@@ -26,7 +26,7 @@ RUN set -eux; \
         apk add --no-cache --virtual .build-deps autoconf re2c gcc make g++ zlib-dev php82-dev; \
         pear82 update-channels; \
         pecl82 update-channels; \
-        pecl82 install --onlyreqdeps --nobuild redis; \
+        pecl82 install --onlyreqdeps --nobuild redis-5.3.7; \
         pecl82 install igbinary; \
         cd "$(pecl82 config-get temp_dir)/redis"; \
         phpize82; \

--- a/php/8.2/Dockerfile
+++ b/php/8.2/Dockerfile
@@ -26,7 +26,7 @@ RUN set -eux; \
         apk add --no-cache --virtual .build-deps autoconf re2c gcc make g++ zlib-dev php82-dev; \
         pear82 update-channels; \
         pecl82 update-channels; \
-        pecl82 install --onlyreqdeps --nobuild redis; \
+        pecl82 install --onlyreqdeps --nobuild redis-5.3.7; \
         pecl82 install igbinary; \
         cd "$(pecl82 config-get temp_dir)/redis"; \
         phpize82; \


### PR DESCRIPTION
When using SncRedisBundle this bug appears: https://github.com/phpredis/phpredis/issues/2385

Reverting to 5.3.7 fixes the problem.